### PR TITLE
fix(deploy): pin available AWS CLI storage image

### DIFF
--- a/deploy/compose.prod.yml
+++ b/deploy/compose.prod.yml
@@ -20,7 +20,7 @@ services:
       - no-new-privileges:true
 
   nix-storage-init:
-    image: amazon/aws-cli:2
+    image: amazon/aws-cli:2.36.31
     profiles: [maintenance]
     restart: "no"
     environment:


### PR DESCRIPTION
Production rollout stopped before migrations because amazon/aws-cli:2 has no published manifest. Pin storage initialization to 2.36.31. Verified its ARM64 pull and execution on the production host; all selected Compose and deployment checks pass. Reviewed the image-only change: credentials, permissions, storage commands, and volumes remain unchanged.