### PR TITLE
fix(deploy): verify retained files separately from note archives

### DIFF
--- a/deploy/compose/check.test.sh
+++ b/deploy/compose/check.test.sh
@@ -38,7 +38,14 @@ command=args[0]
 if command=='auth': print(json.dumps(dict(apiUrl=os.environ.get('TEST_API_URL','https://production.example'))))
 elif command=='import':
  print(json.dumps(dict(rootItemId='smoke-root',createdCount=2,atomic=True,omissions=[],loss=[])))
+elif command=='item' and '--parent' in args:
+ print(json.dumps(dict(items=[dict(id='original-file',type='file')])))
+elif command=='file':
+ path=args[args.index('--out')+1]
+ open(path,'w').write('Nix release smoke test\n\nStorage transfer and document conversion verification.\n')
+ print('{}')
 elif command=='export':
+ assert args[args.index('--scope')+1]=='item'
  fmt=args[args.index('--format')+1]
  if os.environ.get('FAIL_EXPORT')==fmt: sys.exit(1)
  path=args[args.index('--out')+1]

--- a/deploy/compose/smoke.mjs
+++ b/deploy/compose/smoke.mjs
@@ -60,9 +60,17 @@ try {
     throw new Error('Document import did not publish the expected note and retained attachment without omissions.');
   }
   console.log(`Document import passed; temporary root ${root}.`);
+  const children = await run(['item', 'ls', '--workspace', workspace, '--parent', root]);
+  const original = children.items?.find((item) => item.type === 'file');
+  if (!original || children.items.length !== 1) throw new Error('Import did not retain exactly one original attachment.');
+  const retained = join(directory, 'retained.txt');
+  await run(['file', 'download', original.id, '--out', retained]);
+  if (!(await readFile(source)).equals(await readFile(retained))) throw new Error('Retained attachment differs from the imported source.');
+  console.log('Retained attachment download matches the imported source.');
   for (const [format, magic] of [['nix', 'PK'], ['pdf', '%PDF-'], ['docx', 'PK']]) {
     const out = join(directory, `export.${format}`);
-    const result = await run(['export', root, '--format', format, '--scope', format === 'nix' ? 'subtree' : 'item', '--out', out]);
+    // Archive v1 cannot embed file bytes; verify the attachment separately above.
+    const result = await run(['export', root, '--format', format, '--scope', 'item', '--out', out]);
     if (result.omissions?.length || result.omitted > 0) throw new Error(`${format} export omitted content.`);
     const bytes = await readFile(out);
     if (!bytes.subarray(0, magic.length).equals(Buffer.from(magic))) throw new Error(`${format} export has an invalid file signature.`);


### PR DESCRIPTION
The release smoke test attempted a subtree archive containing a retained file, which archive v1 explicitly rejects. Export the imported note in each format and separately download and byte-compare its retained original. Reviewed cleanup and private diagnostic handling. Selected deployment checks pass, and the updated smoke test passes against production for TXT import, retained bytes, Nix archive, PDF, and DOCX.