### PR TITLE
feat(observability): deploy private Grafana log stack

### DIFF
--- a/deploy/compose.prod.env.example
+++ b/deploy/compose.prod.env.example
@@ -57,3 +57,14 @@ CLOUDFLARE_TUNNEL_TOKEN=replace-me
 
 # Separate migration credential; never passed to the running collaboration service.
 NIX_COLLAB_MIGRATOR_CONNECTION_STRING=postgresql://nix_migrator:replace-me@postgres:5432/nix
+
+# Observability. Grafana binds to localhost only, so reach it through SSH port
+# forwarding or a separately authenticated operator route; do not add it to the
+# public Cloudflare tunnel. Rotate this password independently of app secrets.
+NIX_GRAFANA_ADMIN_USER=admin
+NIX_GRAFANA_ADMIN_PASSWORD=replace-me
+NIX_GRAFANA_PORT=3000
+# Pin these on upgrades after validating the release notes in a non-production stack.
+NIX_LOKI_IMAGE_TAG=3.5.5
+NIX_ALLOY_IMAGE_TAG=v1.11.3
+NIX_GRAFANA_IMAGE_TAG=12.2.0

--- a/deploy/compose.prod.yml
+++ b/deploy/compose.prod.yml
@@ -157,6 +157,7 @@ services:
         condition: service_healthy
     environment:
       ASPNETCORE_ENVIRONMENT: Production
+      Logging__Console__FormatterName: json
       ConnectionStrings__Nix: ${NIX_CORE_DATABASE_URL:?set NIX_CORE_DATABASE_URL}
       Nix__InternalSecret: ${NIX_INTERNAL_SECRET:?set NIX_INTERNAL_SECRET}
       Nix__Collaboration__BaseUrl: http://nix-collab:8100
@@ -495,7 +496,96 @@ services:
     security_opt:
       - no-new-privileges:true
 
+  # The proxy grants Alloy read-only access to the small Docker API surface it
+  # needs for discovery and log tailing. Do not mount the Docker socket into
+  # Alloy directly: it is equivalent to root access on the host.
+  docker-socket-proxy:
+    networks: [docker-logs]
+    image: ghcr.io/tecnativa/docker-socket-proxy:v0.4.1
+    restart: unless-stopped
+    environment:
+      CONTAINERS: "1"
+      EVENTS: "1"
+      INFO: "1"
+      NETWORKS: "1"
+      PING: "1"
+      VERSION: "1"
+      POST: "0"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    read_only: true
+    tmpfs:
+      - /run:size=8m,mode=755
+      - /tmp:size=8m,mode=1777
+    mem_limit: 64m
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+
+  loki:
+    networks: [observability]
+    image: grafana/loki:${NIX_LOKI_IMAGE_TAG:-3.5.5}
+    restart: unless-stopped
+    command: ["-config.file=/etc/loki/config.yaml"]
+    volumes:
+      - ./observability/loki.yaml:/etc/loki/config.yaml:ro
+      - nix-loki-data:/loki
+    mem_limit: 512m
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+
+  alloy:
+    networks: [docker-logs, observability]
+    image: grafana/alloy:${NIX_ALLOY_IMAGE_TAG:-v1.11.3}
+    user: "473:473"
+    restart: unless-stopped
+    command: ["run", "--storage.path=/var/lib/alloy", "/etc/alloy/config.alloy"]
+    depends_on:
+      docker-socket-proxy:
+        condition: service_started
+      loki:
+        condition: service_started
+    volumes:
+      - ./observability/alloy-docker.alloy:/etc/alloy/config.alloy:ro
+      - nix-alloy-data:/var/lib/alloy
+    mem_limit: 256m
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+
+  grafana:
+    networks: [observability, grafana-access]
+    image: grafana/grafana:${NIX_GRAFANA_IMAGE_TAG:-12.2.0}
+    restart: unless-stopped
+    depends_on:
+      loki:
+        condition: service_started
+    environment:
+      GF_SECURITY_ADMIN_USER: ${NIX_GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${NIX_GRAFANA_ADMIN_PASSWORD:?set NIX_GRAFANA_ADMIN_PASSWORD}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_AUTH_ANONYMOUS_ENABLED: "false"
+    ports:
+      - "127.0.0.1:${NIX_GRAFANA_PORT:-3000}:3000"
+    volumes:
+      - ./observability/grafana-datasource.yaml:/etc/grafana/provisioning/datasources/nix-logs.yaml:ro
+      - nix-grafana-data:/var/lib/grafana
+    mem_limit: 512m
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+
 networks:
+  grafana-access: {}
+  docker-logs:
+    internal: true
+  observability:
+    internal: true
   default:
     name: nix
     ipam:
@@ -517,3 +607,9 @@ volumes:
     name: nix-caddy-config
   nix-api-data-protection:
     name: nix-api-data-protection
+  nix-loki-data:
+    name: nix-loki-data
+  nix-alloy-data:
+    name: nix-alloy-data
+  nix-grafana-data:
+    name: nix-grafana-data

--- a/deploy/compose/check.test.sh
+++ b/deploy/compose/check.test.sh
@@ -18,6 +18,17 @@ assert s['nix-web']['environment']['NIX_OBJECT_STORE_BUCKET']=='nix-worker-jobs'
 assert 'NIX_COLLAB_MIGRATOR_CONNECTION_STRING' not in s['nix-collab']['environment']
 assert s['nix-collab-migrate']['environment']['NIX_COLLAB_MIGRATOR_CONNECTION_STRING']
 assert not s['nix-versitygw'].get('ports')
+assert set(s['docker-socket-proxy']['networks']) == {'docker-logs'}
+assert set(s['alloy']['networks']) == {'docker-logs', 'observability'}
+assert set(s['loki']['networks']) == {'observability'}
+assert set(s['grafana']['networks']) == {'observability', 'grafana-access'}
+assert c['networks']['docker-logs']['internal']
+assert c['networks']['observability']['internal']
+assert s['docker-socket-proxy']['environment']['POST'] == '0'
+assert not s['docker-socket-proxy'].get('ports')
+assert not s['loki'].get('ports')
+assert s['grafana']['ports'][0]['host_ip'] == '127.0.0.1'
+assert s['grafana']['environment']['GF_AUTH_ANONYMOUS_ENABLED'] == 'false'
 from pathlib import Path
 edge=Path('deploy/Caddyfile.prod').read_text()
 exchange=edge.split('handle /public/v1/auth/token {',1)[1].split('\n\thandle ',1)[0]

--- a/deploy/observability/alloy-docker.alloy
+++ b/deploy/observability/alloy-docker.alloy
@@ -1,0 +1,34 @@
+// Docker discovery tails Nix containers through the Docker API.
+// Keep labels deliberately low-cardinality. Request, workspace, and job IDs belong
+// in structured log fields and must never become Loki labels.
+discovery.docker "nix" {
+  host = "tcp://docker-socket-proxy:2375"
+
+  filter {
+    name = "label"
+    values = ["com.docker.compose.project=nix"]
+  }
+}
+
+discovery.relabel "nix" {
+  targets = discovery.docker.nix.targets
+
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = "/(.*)"
+    target_label  = "service"
+  }
+}
+
+loki.source.docker "nix" {
+  host       = "tcp://docker-socket-proxy:2375"
+  targets    = discovery.relabel.nix.output
+  labels     = { environment = "production" }
+  forward_to = [loki.write.nix.receiver]
+}
+
+loki.write "nix" {
+  endpoint {
+    url = "http://loki:3100/loki/api/v1/push"
+  }
+}

--- a/deploy/observability/grafana-datasource.yaml
+++ b/deploy/observability/grafana-datasource.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Nix logs
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: true
+    editable: false

--- a/deploy/observability/loki.yaml
+++ b/deploy/observability/loki.yaml
@@ -1,0 +1,44 @@
+# Single-node Loki for a Nix installation. The persistent volume must be monitored:
+# filesystem storage enforces retention, but cannot protect the host from a full disk.
+auth_enabled: false
+
+analytics:
+  reporting_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: "2026-01-01"
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  filesystem:
+    directory: /loki/chunks
+  tsdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/index-cache
+
+compactor:
+  working_directory: /loki/compactor
+  compaction_interval: 10m
+  retention_enabled: true
+  delete_request_store: filesystem
+
+limits_config:
+  retention_period: 720h
+  allow_structured_metadata: false


### PR DESCRIPTION
Add Grafana, Loki, and Alloy for production Nix container logs, with 30-day retention and JSON Core console output. Grafana binds to localhost; Loki and the read-only Docker socket proxy use isolated networks. Discovery collects only the Nix Compose project. Correct the proxy image reference and run Alloy as its storage-owning user. Security and deployment review verified network isolation, blocked proxy write/secret endpoints, persistent volume ownership, and unchanged application images. Selected Compose checks pass. An isolated ARM64 host test confirms authenticated Grafana access, Loki datasource health, and logs from all 12 Nix services.